### PR TITLE
Jacdac Extension

### DIFF
--- a/jacdac/README.md
+++ b/jacdac/README.md
@@ -1,1 +1,2 @@
 # Jacdac support for Monkmake 7 segment
+

--- a/jacdac/README.md
+++ b/jacdac/README.md
@@ -1,0 +1,1 @@
+# Jacdac support for Monkmake 7 segment

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -8,7 +8,7 @@ namespace modules {
      * Client for the MonkMakes 7-segment accesory
      */
     //% fixedInstance whenUsed block="MonkMakes 7 segment"
-    export const monkMakes7Segment = new SevenSegmentDisplayClient("MonkMakes 7 segment?device=self")
+    export const monkMakes7Segment = new SevenSegmentDisplayClient("MonkMakes 7 segment?dev=self&digits=4&decimal_point=true&double_dots=false")
 }
 
 namespace servers {
@@ -16,10 +16,30 @@ namespace servers {
         digits: Buffer = control.createBuffer(0)
         constructor() {
             super(jacdac.SRV_SEVEN_SEGMENT_DISPLAY)
+
+            this.setStatusCode(jacdac.SystemStatusCodes.Initializing)
+            control.inBackground(() => {
+                sevenSegment.startSevenSegPin0()
+                pause(200)
+                this.setStatusCode(jacdac.SystemStatusCodes.Ready)
+            })
         }
 
         handlePacket(pkt: jacdac.JDPacket) {
+            // constants
+            this.handleRegFormat(pkt, 
+                jacdac.SevenSegmentDisplayReg.DigitCount, 
+                jacdac.SevenSegmentDisplayRegPack.DigitCount, 
+                [4])
+            this.handleRegBool(pkt, 
+                jacdac.SevenSegmentDisplayReg.DecimalPoint, 
+                true)
+            this.handleRegBool(pkt, 
+                jacdac.SevenSegmentDisplayReg.DoubleDots, 
+                false)
+
             this.digits = this.handleRegBuffer(pkt, jacdac.SevenSegmentDisplayReg.Digits, this.digits)
+
             // convert back to characters
             const digitBits = [
                 0b00111111, // 0

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -1,11 +1,21 @@
 //% deprecated
 namespace sevenSegment {
 }
+
+
+namespace modules {
+    /**
+     * Client for the MonkMakes 7-segment accesory
+     */
+    //% fixedInstance whenUsed block="MonkMakes 7 segment"
+    export const monkMakes7Segment = new SevenSegmentDisplayClient("MonkMakes 7 segment?device=self")
+}
+
 namespace servers {
     class SevenSegmentServer extends jacdac.Server {
         digits: Buffer = control.createBuffer(0)
         constructor() {
-            super("", jacdac.SRV_SEVEN_SEGMENT_DISPLAY)
+            super(jacdac.SRV_SEVEN_SEGMENT_DISPLAY)
         }
 
         handlePacket(pkt: jacdac.JDPacket) {
@@ -49,12 +59,4 @@ namespace servers {
         ])
     }
     start()
-}
-
-namespace modules {
-    /**
-     * Client for the MonkMakes 7-segment accesory
-     */
-    //% fixedInstance whenUsed block="MonkMakes 7-segment"
-    export const monkMakes7Segment = new SevenSegmentDisplayClient("MonkMakes 7-segment?device=self")
 }

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -74,6 +74,7 @@ namespace servers {
         }
     }
     function start() {
+        jacdac.productIdentifier = 0x38ef2074
         jacdac.startSelfServers(() => [
             new SevenSegmentServer()
         ])

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -8,16 +8,14 @@ namespace modules {
      * Client for the MonkMakes 7-segment accesory
      */
     //% fixedInstance whenUsed block="MonkMakes 7 segment"
-    export const monkMakes7Segment = new SevenSegmentDisplayClient("MonkMakes 7 segment?dev=self&digits=4&decimal_point=true&double_dots=false")
+    export const monkMakes7Segment = new SevenSegmentDisplayClient("MonkMakes 7 segment?dev=self&digits=4&decimal_point=1&double_dots=0")
 }
 
 namespace servers {
     class SevenSegmentServer extends jacdac.Server {
         digits: Buffer = control.createBuffer(0)
         constructor() {
-            super(jacdac.SRV_SEVEN_SEGMENT_DISPLAY)
-
-            this.setStatusCode(jacdac.SystemStatusCodes.Initializing)
+            super(jacdac.SRV_SEVEN_SEGMENT_DISPLAY, { statusCode: jacdac.SystemStatusCodes.Initializing })
             control.inBackground(() => {
                 sevenSegment.startSevenSegPin0()
                 pause(200)
@@ -27,15 +25,15 @@ namespace servers {
 
         handlePacket(pkt: jacdac.JDPacket) {
             // constants
-            this.handleRegFormat(pkt, 
-                jacdac.SevenSegmentDisplayReg.DigitCount, 
-                jacdac.SevenSegmentDisplayRegPack.DigitCount, 
+            this.handleRegFormat(pkt,
+                jacdac.SevenSegmentDisplayReg.DigitCount,
+                jacdac.SevenSegmentDisplayRegPack.DigitCount,
                 [4])
-            this.handleRegBool(pkt, 
-                jacdac.SevenSegmentDisplayReg.DecimalPoint, 
+            this.handleRegBool(pkt,
+                jacdac.SevenSegmentDisplayReg.DecimalPoint,
                 true)
-            this.handleRegBool(pkt, 
-                jacdac.SevenSegmentDisplayReg.DoubleDots, 
+            this.handleRegBool(pkt,
+                jacdac.SevenSegmentDisplayReg.DoubleDots,
                 false)
 
             this.digits = this.handleRegBuffer(pkt, jacdac.SevenSegmentDisplayReg.Digits, this.digits)
@@ -75,6 +73,7 @@ namespace servers {
     }
     function start() {
         jacdac.productIdentifier = 0x38ef2074
+        jacdac.deviceDescription = "MonkMakes 7-Segment"
         jacdac.startSelfServers(() => [
             new SevenSegmentServer()
         ])

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -2,11 +2,59 @@
 namespace sevenSegment {
 }
 namespace servers {
-    function start() {
-        if (jacdac.isSimulator()) {
-
+    class SevenSegmentServer extends jacdac.Server {
+        digits: Buffer = control.createBuffer(0)
+        constructor() {
+            super("", jacdac.SRV_SEVEN_SEGMENT_DISPLAY)
         }
-        if (jacdac.checkProxy()) jacdac.proxyFinalize()
+
+        handlePacket(pkt: jacdac.JDPacket) {
+            this.digits = this.handleRegBuffer(pkt, jacdac.SevenSegmentDisplayReg.Digits, this.digits)
+            // convert back to characters
+            const digitBits = [
+                0b00111111, // 0
+                0b00000110, // 1
+                0b01011011, // 2
+                0b01001111, // 3
+                0b01100110, // 4
+                0b01101101, // 5
+                0b01111101, // 6
+                0b00000111, // 7
+                0b01111111, // 8
+                0b01101111, // 9
+            ]
+            let text = ""
+            const digits = this.digits
+            for (let i = 0; i < digits.length; ++i) {
+                let d = digits[i]
+                let dot = false
+                if (d & 0b10000000) {
+                    dot = true
+                    d &= ~0b10000000
+                }
+                let k = digitBits.indexOf(d)
+                if (k > -1)
+                    text += k.toString()
+                else if (k == 0b01000000) // -
+                    text += "-"
+                if (dot)
+                    text += "."
+            }
+            sevenSegment.writeString(text)
+        }
+    }
+    function start() {
+        jacdac.startSelfServers(() => [
+            new SevenSegmentServer()
+        ])
     }
     start()
+}
+
+namespace modules {
+    /**
+     * Client for the MonkMakes 7-segment accesory
+     */
+    //% fixedInstance whenUsed block="MonkMakes 7-segment"
+    export const monkMakes7Segment = new SevenSegmentDisplayClient("MonkMakes 7-segment?device=self")
 }

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -1,0 +1,12 @@
+//% deprecated
+namespace sevenSegment {
+}
+namespace servers {
+    function start() {
+        if (jacdac.isSimulator()) {
+
+        }
+        if (jacdac.checkProxy()) jacdac.proxyFinalize()
+    }
+    start()
+}

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,13 +1,13 @@
 {
-    "name": "jacdac-monkmakes-7-segment",
+    "name": "monkmakes-7-segment-jacdac",
     "version": "1.0.1",
     "dependencies": {
         "core": "*",
         "radio": "*",
         "microphone": "*",
         "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.9.3",
-        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.9.3"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.3",
+        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.3"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.0.18",
+        "target": "4.1.24",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,5 +1,5 @@
 {
-    "name": "jacdac",
+    "name": "jacdac-monkmakes-7-segment",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -5,7 +5,8 @@
         "radio": "*",
         "microphone": "*",
         "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.8.18"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.8.18",
+        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.8.24"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -5,15 +5,18 @@
         "radio": "*",
         "microphone": "*",
         "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.8.18",
-        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.8.24"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.9.3",
+        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.9.3"
     },
     "files": [
         "main.ts",
         "README.md"
     ],
+    "testFiles": [
+        "test.ts"
+    ],
     "targetVersions": {
-        "target": "4.1.16",
+        "target": "4.0.18",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "monkmakes-7-segment-jacdac",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "monkmakes-7-segment-jacdac",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "monkmakes-7-segment-jacdac",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.3",
-        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.3"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.5",
+        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.5"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
-        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.14"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.24",
+        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.24"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.27",
+        "target": "4.1.30",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "monkmakes-7-segment-jacdac",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,5 +1,6 @@
 {
     "name": "jacdac-monkmakes-7-segment",
+    "version": "1.0.1",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.24",
-        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.24"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.31",
+        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.31"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.30",
+        "target": "4.1.34",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "monkmakes-7-segment-jacdac",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "monkmakes-7-segment-jacdac",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,0 +1,22 @@
+{
+    "name": "jacdac",
+    "dependencies": {
+        "core": "*",
+        "radio": "*",
+        "microphone": "*",
+        "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
+        "jacdac": "github:microsoft/pxt-jacdac#v0.8.18"
+    },
+    "files": [
+        "main.ts",
+        "README.md"
+    ],
+    "targetVersions": {
+        "target": "4.1.16",
+        "targetId": "microbit"
+    },
+    "supportedTargets": [
+        "microbit"
+    ],
+    "preferredEditor": "tsprj"
+}

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.31",
-        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.31"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.41",
+        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.41"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.34",
+        "target": "4.1.44",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "MonkMakes 7-Segment": "github:monkmakes/monkmakes-7-segment#v1.0.0",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.5",
-        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.5"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
+        "jacdac-seven-segment-display": "github:microsoft/pxt-jacdac/seven-segment-display#v0.10.14"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.24",
+        "target": "4.1.27",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/test.ts
+++ b/jacdac/test.ts
@@ -1,0 +1,6 @@
+let i = 0
+input.onButtonPressed(Button.A, () => i = 0)
+forever(() => {
+    modules.monkMakes7Segment.setNumber(i++)    
+    pause(100)
+})


### PR DESCRIPTION
This pull requests add support for Jacdac for this accessory which allows users to use simulators in MakeCode. Jacdac support will be released in the next major release of MakeCode for micro:bit (summer 2022).

-   This change adds a new nested extension (`jacdac` folder)
and does not modify the existing extension. **Your existing lessons, tutorials and blocks are not impacted by this change.**
-   No hardware modification is required for existing accessories, this feature
is [backward compatible](https://microsoft.github.io/jacdac-docs/ddk/microbit/software-only-accessory/). However, it requires a micro:bit V2 to run.

The benefits for the users and you will be:

-   **Simulator** Jacdac enables simulations of all sensors and actuators
-   **Digital twins** Jacdac surfaces the hardware state directly into the MakeCode editor
-   **Standardized blocks and lessons** the programming will be done through
Jacdac blocks maintained by the Microsoft team

![image](https://user-images.githubusercontent.com/4175913/170540491-6b6901ef-7574-45fe-972b-66ea8022647e.png)

We recommend reading the [Jacdac software only accessory](https://microsoft.github.io/jacdac-docs/ddk/microbit/software-only-accessory/) documentation page to learn more 
about the details of this approach. You can also review a list of similar [software only extensions](https://microsoft.github.io/jacdac-docs/ddk/microbit/extension-samples/).

Please do not hesitate to contact us through this pull request or at jacdac-tap@microsoft.com 
if you have any question or want to schedule a call.

## How to test this extension as a user?

**This features requires to beta editor of MakeCode at https://makecode.microbit.org/beta.**

- Click on https://microsoft.github.io/jacdac-docs/ddk/microbit/extension-samples/
- Find the extension for this accessory
- Click on **Try MakeCode** to open a project that as a user
- Use the blocks from the **Modules** toolbox

You can follow the [micro:bit Jacdac guide](https://microsoft.github.io/jacdac-docs/clients/makecode/) to learn how Jacdac integrates into MakeCode

## TODOs

- [ ] merge this pull request (squash recommended)
- [ ] create a new release for the repository
- [ ] review the accessory page in the [Jacdac device catalog](https://microsoft.github.io/jacdac-docs/devices/) to make sure we got all the details right

Once the pull request is merged, we will update the catalog to point to it rather than our temporary fork.

## Future accessories TODOs

- Review the [micro:bit accessory Jacdac integration guide](https://microsoft.github.io/jacdac-docs/ddk/microbit/) to learn how you can integrate Jacdac into your future accessories for a better user experience. We provide various options to integrate Jacdac into your hardware at minimal cost.
- Review the [Jacdac Device Development Kit](https://microsoft.github.io/jacdac-docs/ddk/) for more details about hardware integration of Jacdac in general.
- Contact us if you have any question about adding Jacdac to your next accessory through [Discussions](https://github.com/microsoft/jacdac/discussions) or at jacdac-tag@microsoft.com.
 
